### PR TITLE
Update _video.scss

### DIFF
--- a/lib/embed/_video.scss
+++ b/lib/embed/_video.scss
@@ -8,7 +8,7 @@
   #poster {
     position: relative;
     overflow: hidden;
-    max-height: 100 / 16 * 9 px;
+    max-height: 100 / 16 * 9px;
 
     img {
       display: block;


### PR DESCRIPTION
FIx wrong SASS math.

### Summary
Fix the calculation of #poster max-height.
It is wrong because the px unit contains a space character.

INCLUDE CODE EXAMPLES AND SCREENSHOTS IF APPLICABLE
![image](https://user-images.githubusercontent.com/552979/41027623-c4fb3558-6977-11e8-8898-92115c6c3aa5.png)


### Motivation
Bug fixing
